### PR TITLE
Hide explore by default to prevent crash on UWP.

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1686,7 +1686,7 @@ static struct config_bool_setting *populate_settings_bool(
    SETTING_BOOL("content_show_add",              &settings->bools.menu_content_show_add, true, DEFAULT_MENU_CONTENT_SHOW_ADD, false);
    SETTING_BOOL("content_show_playlists",        &settings->bools.menu_content_show_playlists, true, content_show_playlists, false);
 #if defined(HAVE_LIBRETRODB)
-   SETTING_BOOL("content_show_explore",          &settings->bools.menu_content_show_explore, true, DEFAULT_MENU_CONTENT_SHOW_EXPLORE, false);
+   SETTING_BOOL("content_show_explore",          &settings->bools.menu_content_show_explore, false, DEFAULT_MENU_CONTENT_SHOW_EXPLORE, false);
 #endif
    SETTING_BOOL("menu_show_load_core",           &settings->bools.menu_show_load_core, true, menu_show_load_core, false);
    SETTING_BOOL("menu_show_load_content",        &settings->bools.menu_show_load_content, true, menu_show_load_content, false);


### PR DESCRIPTION
The Explore tab on UWP (or more specifically Xbox) can cause a crash in RetroArch, by hiding it, RetroArch no longer crashes.

@twinaphex
